### PR TITLE
Clean up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,2 @@
 language: node_js
-node_js: 10.13.0
-cache: npm
-script: npm run test
+node_js: node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: node_js
-node_js: node
+node_js: 10.13.0


### PR DESCRIPTION
1. `npm run test` is default for `laguage: node_js`
2. `cache: npm` is default for `laguage: node_js`
3. `node` will use the latest Node.js, which will make test faster and will be closer to browser’s JS engine,