### PR TITLE
Returns single quotes back

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,14 +1,14 @@
-import { AppPage } from "./app.po";
+import { AppPage } from './app.po';
 
-describe("workspace-project App", () => {
+describe('workspace-project App', () => {
   let page: AppPage;
 
   beforeEach(() => {
     page = new AppPage();
   });
 
-  it("should display welcome message", () => {
+  it('should display welcome message', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toEqual("Welcome to storeon-angular!");
+    expect(page.getParagraphText()).toEqual('Welcome to storeon-angular!');
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,8 +1,8 @@
-import { TestBed, async } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
-import { AppComponent } from "./app.component";
+import { TestBed, async } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppComponent } from './app.component';
 
-describe("AppComponent", () => {
+describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
@@ -10,7 +10,7 @@ describe("AppComponent", () => {
     }).compileComponents();
   }));
 
-  it("should create the app", () => {
+  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
@@ -19,15 +19,15 @@ describe("AppComponent", () => {
   it(`should have as title 'storeon-angular'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual("storeon-angular");
+    expect(app.title).toEqual('storeon-angular');
   });
 
-  it("should render title in a h1 tag", () => {
+  it('should render title in a h1 tag', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector("h1").textContent).toContain(
-      "Welcome to storeon-angular!"
+    expect(compiled.querySelector('h1').textContent).toContain(
+      'Welcome to storeon-angular!'
     );
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,25 +1,25 @@
-import { Component, OnInit } from "@angular/core";
-import { NgStoreonService } from "@storeon/angular";
-import { Subject } from "rxjs";
+import { Component, OnInit } from '@angular/core';
+import { NgStoreonService } from '@storeon/angular';
+import { Subject } from 'rxjs';
 
 @Component({
-  selector: "app-root",
-  templateUrl: "./app.component.html",
-  styleUrls: ["./app.component.scss"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
   changes: Subject<any>;
   dispatch: Function;
   constructor(private ngstoreon: NgStoreonService) {}
-  title = "storeon-angular";
+  title = 'storeon-angular';
 
   ngOnInit() {
-    const { dispatch, changes } = this.ngstoreon.useStoreon("count");
+    const { dispatch, changes } = this.ngstoreon.useStoreon('count');
     this.dispatch = dispatch;
     this.changes = changes;
   }
 
   updateState() {
-    this.dispatch("inc");
+    this.dispatch('inc');
   }
 }


### PR DESCRIPTION
In the previous PR #9 my code editor automatically replaced single quotes with double quotes, and I didn’t pay attention.
To avoid this in the future, it may be worth using a [Prettier](https://prettier.io) with a [Husky](https://github.com/typicode/husky) pre-commit hook?